### PR TITLE
merge global and service handlers & formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ PayloadTranslator.configure do |config|
     get_country: ->(payload) { payload['name'] },
   }
 end
+```
 
+Or per service
+
+```ruby
+PayloadTranslator::Service(config, handlers: get_country: ->(payload) { payload['name'] })
 ```
 
 ## Configure formatters
@@ -74,4 +79,10 @@ PayloadTranslator.configure do |config|
     to_integer: ->(value) { value.to_i },
   }
 end
+```
+
+Or formatter per service
+
+```ruby
+PayloadTranslator::Service(config, formatters: to_integer: ->(value) { value.to_i })
 ```

--- a/lib/payload_translator/field_resolver.rb
+++ b/lib/payload_translator/field_resolver.rb
@@ -1,10 +1,11 @@
 module PayloadTranslator
   class FieldResolver
-    attr_reader :config, :handlers, :formatters
+    attr_reader :config, :handlers, :formatters, :configuration
 
-    def initialize(field_config)
-      @handlers = PayloadTranslator.configuration.handlers
-      @formatters = PayloadTranslator.configuration.formatters
+    def initialize(field_config, configuration)
+      @configuration = configuration
+      @handlers = configuration.handlers
+      @formatters = configuration.formatters
       @config = field_config
     end
 
@@ -51,7 +52,7 @@ module PayloadTranslator
 
     def resolve_deep_object(payload)
       config.each_with_object({}) do |(target_name, field_config), result|
-        result[target_name] = FieldResolver.new(field_config).resolve(payload)
+        result[target_name] = FieldResolver.new(field_config, configuration).resolve(payload)
       end
     end
 

--- a/lib/payload_translator/service.rb
+++ b/lib/payload_translator/service.rb
@@ -1,14 +1,22 @@
 module PayloadTranslator
   class Service
-    attr_reader :config
+    attr_reader :adapt_config, :configuration
 
-    def initialize(config)
-      @config = config
+    def initialize(adapt_config, handlers: {}, formatters: {})
+      @adapt_config = adapt_config
+      @configuration = merge_configuration(handlers: handlers, formatters: formatters)
+    end
+
+    def merge_configuration(handlers: , formatters:)
+      PayloadTranslator::Config.new.tap do |config|
+        config.handlers = PayloadTranslator.configuration.handlers.merge(handlers)
+        config.formatters = PayloadTranslator.configuration.formatters.merge(formatters)
+      end
     end
 
     def translate(payload)
-      config["payload"].each_with_object({}) do |(target_name, field_config), result|
-        result[target_name] = FieldResolver.new(field_config).resolve(payload)
+      adapt_config["payload"].each_with_object({}) do |(target_name, field_config), result|
+        result[target_name] = FieldResolver.new(field_config, configuration).resolve(payload)
       end
     end
   end

--- a/spec/payload_translator_spec.rb
+++ b/spec/payload_translator_spec.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require 'payload_translator'
 require 'yaml'
 require 'json'
@@ -5,7 +6,6 @@ require 'json'
 PayloadTranslator.configure do |config|
   config.formatters = {
     uppercase: ->(value) { value.upcase },
-    to_integer: ->(value) { value.to_i },
   }
   config.handlers = {
     get_name: ->(payload) { payload['name'] },
@@ -42,6 +42,10 @@ describe PayloadTranslator::Service do
 
   context "with map formatter" do
     let(:context) { "with_map_formatter" }
+    let(:subject) {
+      formatters = { to_integer: ->(value) { value.to_i } }
+      PayloadTranslator::Service.new(config, formatters: formatters)
+    }
 
     it '#translate' do
       expect(subject.translate(input)).to eq("login_type" => "APP", "id" => 1)


### PR DESCRIPTION
Allow set  handler or formatter per service instance

Example:
```ruby
PayloadTranslator::Service(config, handlers: get_country: ->(payload) { payload['name'] })
```