### PR TITLE
Fetch field fnc

### DIFF
--- a/lib/payload_translator/field_resolver.rb
+++ b/lib/payload_translator/field_resolver.rb
@@ -23,7 +23,7 @@ module PayloadTranslator
 
     def resolve_value(payload)
       with_formatter do
-        payload[config["$field"]]
+        payload[fetch_field(payload)]
       end
     end
 
@@ -40,7 +40,7 @@ module PayloadTranslator
     end
 
     def resolve_map(payload)
-      value = payload[config["$field"]]
+      value = payload[fetch_field(payload)]
       return config["$default"] unless value
       if config["$map_formatter"]
         fotmatter = formatters.fetch(config["$map_formatter"].to_sym)
@@ -53,6 +53,13 @@ module PayloadTranslator
     def resolve_deep_object(payload)
       config.each_with_object({}) do |(target_name, field_config), result|
         result[target_name] = FieldResolver.new(field_config, configuration).resolve(payload)
+      end
+    end
+
+    def fetch_field(payload)
+      config.fetch("$field") do
+        hander = handlers.fetch(config.fetch("$field_fnc").to_sym)
+        hander.call(payload)
       end
     end
 

--- a/spec/fixtures/with_fnc/config.yaml
+++ b/spec/fixtures/with_fnc/config.yaml
@@ -1,3 +1,5 @@
 payload:
   user_name:
     $fnc: get_name
+  id:
+    $field_fnc: fetch_id

--- a/spec/payload_translator_spec.rb
+++ b/spec/payload_translator_spec.rb
@@ -9,6 +9,7 @@ PayloadTranslator.configure do |config|
   }
   config.handlers = {
     get_name: ->(payload) { payload['name'] },
+    fetch_id: ->(payload) { payload['_id'] }
   }
 end
 
@@ -28,7 +29,15 @@ describe PayloadTranslator::Service do
     let(:context) { "with_fnc" }
 
     it '#translate' do
-      expect(subject.translate(input)).to eq({"user_name"=>"Jhon Doe"})
+      expect(subject.translate(input)).to eq({"user_name"=>"Jhon Doe","id" => "1"})
+    end
+  end
+
+  context "with $field_fnc" do
+    let(:context) { "with_fnc" }
+
+    it '#translate' do
+      expect(subject.translate(input)).to eq({"user_name"=>"Jhon Doe","id" => "1"})
     end
   end
 

--- a/spec/payload_translator_spec.rb
+++ b/spec/payload_translator_spec.rb
@@ -9,7 +9,7 @@ PayloadTranslator.configure do |config|
   }
   config.handlers = {
     get_name: ->(payload) { payload['name'] },
-    fetch_id: ->(payload) { payload['_id'] }
+    fetch_id: ->(payload) { '_id' }
   }
 end
 


### PR DESCRIPTION
Allow custom implementation to fetch the payload field

```yaml
payload:
  id:
    $field_fnc: fetch_id
```

```ruby
PayloadTranslator.configure do |config|
  config.handlers = {
    fetch_id: ->(payload) {  '_id'  }
  }
end
```