### PR TITLE
Translate array

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,48 @@ end
 ```ruby
 translator = PayloadTranslator::Service.new(:internal_to_extenal)
 ```
+
+### Complex adapters
+
+Translate all array items, use `$field_for_all_items` special propery of the first elemtn of the array to apply the same translation from the same field
+Config:
+
+```yaml
+payload:
+  countries:
+    - $field_for_all_items: countries
+      name:
+        $field: 'name'
+```
+
+Input:
+
+```json
+{
+  "countries": [
+    {
+      "name": "US",
+      "code": "US_CODE"
+    },
+    {
+      "name": "AU",
+      "code": "AU_CODE"
+    }
+  ]
+}
+```
+
+Result:
+
+```json
+{
+  "countries": [
+    {
+      "name": "US"
+    },
+    {
+      "name": "AU"
+    }
+  ]
+}
+```

--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'pry'
+require 'yaml'
 require_relative '../lib/payload_translator'
 
 Pry.start

--- a/lib/payload_translator/field_resolver.rb
+++ b/lib/payload_translator/field_resolver.rb
@@ -11,7 +11,9 @@ module PayloadTranslator
 
     def resolve(payload)
       @payload = payload
-      if deep_object?
+      if is_a_array?
+        resolve_array
+      elsif deep_object?
         resolve_deep_object
       elsif config["$fnc"]
         resolve_fnc
@@ -50,6 +52,14 @@ module PayloadTranslator
       end
     end
 
+    def resolve_array
+      [].tap do |result|
+        config.each_with_index do |field_config, index|
+          result[index] = FieldResolver.new(field_config, configuration).resolve(payload)
+        end
+      end
+    end
+
     def search_value(field_or_fields)
       Payload.search_value(payload, field_or_fields, config["$default"])
     end
@@ -76,6 +86,10 @@ module PayloadTranslator
       when 2
         handler.call(payload, config)
       end
+    end
+
+    def is_a_array?
+      config.is_a?(Array)
     end
 
     def deep_object?

--- a/lib/payload_translator/field_resolver.rb
+++ b/lib/payload_translator/field_resolver.rb
@@ -1,4 +1,5 @@
 module PayloadTranslator
+  class ArrayFieldError < StandardError; end
   class FieldResolver
     attr_reader :config, :handlers, :formatters, :configuration, :payload
 
@@ -56,6 +57,7 @@ module PayloadTranslator
       @config = config
       [].tap do |result|
         sub_payload = search_value(config["$field_for_all_items"])
+        raise ArrayFieldError.new("Field $field_for_all_items should be an Array an is: #{sub_payload}") unless sub_payload.is_a?(Array)
         sub_payload.map.with_index do |sub_payload_item, index|
           field_config = config.reject{|key| key == "$field_for_all_items"}
           result[index] = FieldResolver.new(field_config, configuration).resolve(sub_payload_item)

--- a/lib/payload_translator/field_resolver.rb
+++ b/lib/payload_translator/field_resolver.rb
@@ -52,7 +52,20 @@ module PayloadTranslator
       end
     end
 
+    def resolve_array_all_items(config)
+      @config = config
+      [].tap do |result|
+        sub_payload = search_value(config["$field_for_all_items"])
+        sub_payload.map.with_index do |sub_payload_item, index|
+          field_config = config.reject{|key| key == "$field_for_all_items"}
+          result[index] = FieldResolver.new(field_config, configuration).resolve(sub_payload_item)
+        end
+      end
+    end
+
     def resolve_array
+      return resolve_array_all_items(config.first) if config.first["$field_for_all_items"]
+
       [].tap do |result|
         config.each_with_index do |field_config, index|
           result[index] = FieldResolver.new(field_config, configuration).resolve(payload)

--- a/spec/fixtures/with_array/config.yaml
+++ b/spec/fixtures/with_array/config.yaml
@@ -1,0 +1,8 @@
+payload:
+  addresses:
+  - type:
+      $default: shipping
+    city:
+      $field: shipping.city
+    state:
+      $field: shipping.state

--- a/spec/fixtures/with_array/config.yaml
+++ b/spec/fixtures/with_array/config.yaml
@@ -1,4 +1,8 @@
 payload:
+  countries:
+  - $field_for_all_items: countries
+    name:
+      $field: "name"
   addresses:
   - type:
       $field: ""

--- a/spec/fixtures/with_array/config.yaml
+++ b/spec/fixtures/with_array/config.yaml
@@ -1,6 +1,7 @@
 payload:
   addresses:
   - type:
+      $field: ""
       $default: shipping
     city:
       $field: shipping.city

--- a/spec/fixtures/with_array/input.json
+++ b/spec/fixtures/with_array/input.json
@@ -1,4 +1,14 @@
 {
+  "countries": [
+    {
+      "name": "US",
+      "code": "US_CODE"
+    },
+    {
+      "name": "AU",
+      "code": "AU_CODE"
+    }
+  ],
   "shipping": {
     "street": "Street 1",
     "city": "City",

--- a/spec/fixtures/with_array/input.json
+++ b/spec/fixtures/with_array/input.json
@@ -1,0 +1,9 @@
+{
+  "shipping": {
+    "street": "Street 1",
+    "city": "City",
+    "state": "State",
+    "country": "Country",
+    "zipCode": "Zip code"
+  }
+}

--- a/spec/payload_translator_spec.rb
+++ b/spec/payload_translator_spec.rb
@@ -96,4 +96,11 @@ describe PayloadTranslator::Service do
       expect(subject.translate(input)).to eq("login_type" => "APP", "id" => 1)
     end
   end
+
+  context "with array" do
+    let(:context) { "with_array"}
+    it '#translate' do
+      expect(subject.translate(input)).to eq({"addresses" => [{"type" => "shipping", "city" => "City", "state" => "State"}]})
+    end
+  end
 end

--- a/spec/payload_translator_spec.rb
+++ b/spec/payload_translator_spec.rb
@@ -100,7 +100,12 @@ describe PayloadTranslator::Service do
   context "with array" do
     let(:context) { "with_array"}
     it '#translate' do
-      expect(subject.translate(input)).to eq({"addresses" => [{"type" => "shipping", "city" => "City", "state" => "State"}]})
+      expect(subject.translate(input)).to(
+        eq({
+          "addresses" => [{"city"=>"City", "state"=>"State", "type"=>"shipping"}],
+          "countries" => [{"name" => "US"}, {"name" => "AU"}]
+        })
+      )
     end
   end
 end

--- a/spec/payload_translator_spec.rb
+++ b/spec/payload_translator_spec.rb
@@ -107,5 +107,11 @@ describe PayloadTranslator::Service do
         })
       )
     end
+
+    it '#translate with error' do
+      expect{ subject.translate(input.merge({"countries" => "STRING"}))}.to raise_error(
+        PayloadTranslator::ArrayFieldError
+      )
+    end
   end
 end


### PR DESCRIPTION
Translate all array items, use `$field_for_all_items` special propery of the first elemtn of the array to apply the same translation from the same field
Config:

```yaml
payload:
  countries:
    - $field_for_all_items: countries
      name:
        $field: 'name'
```

Input:

```json
{
  "countries": [
    {
      "name": "US",
      "code": "US_CODE"
    },
    {
      "name": "AU",
      "code": "AU_CODE"
    }
  ]
}
```

Result:

```json
{
  "countries": [
    {
      "name": "US"
    },
    {
      "name": "AU"
    }
  ]
}
```