### PR TITLE
Translate input and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Store adapter configuration
 ```ruby
 PayloadTranslator.configure do |config|
   config.adapters_configurations = {
-    internal_to_extenal: {
+    internal_to_external: {
       "payload" => {
         "id" => { "$field" => "_id" }
       }
@@ -104,7 +104,22 @@ end
 ```
 
 ```ruby
-translator = PayloadTranslator::Service.new(:internal_to_extenal)
+translator = PayloadTranslator::Service.new(:internal_to_external)
+```
+
+### Multiple translator
+
+```ruby
+translator = PayloadTranslator::ServiceMultiple.new([:internal_to_external, :external_to_internal])
+
+translated_response = translator.translate({"user_id" => 4 }) do |translated_payload|
+  response = Net::HTTP.post_form(
+    URI("https://jsonplaceholder.typicode.com/todos"),
+    translated_payload
+  ).body
+
+  JSON.parse(response)
+end
 ```
 
 ### Complex adapters

--- a/bin/console
+++ b/bin/console
@@ -3,6 +3,25 @@
 
 require 'pry'
 require 'yaml'
+require 'net/http'
+require 'json'
 require_relative '../lib/payload_translator'
+
+PayloadTranslator.configure do |config|
+  config.adapters_configurations = {
+    internal_to_external: {
+      "payload" => {
+        "id" => { "$field" => "_id" },
+        "userId" => { "$field" => "user_id" }
+      }
+    },
+    external_to_internal: {
+      "payload" => {
+        "_id" => { "$field" => "id" },
+        "user_id" => { "$field" => "userId" }
+      }
+    }
+  }
+end
 
 Pry.start

--- a/lib/payload_translator/service_multiple.rb
+++ b/lib/payload_translator/service_multiple.rb
@@ -1,0 +1,18 @@
+module PayloadTranslator
+  class ServiceMultiple < Service
+    attr_reader :translators
+    def initialize(adapter_configs_or_names, handlers: {}, formatters: {})
+      @translators = adapter_configs_or_names.map do |adapter_config_or_name|
+        Service.new(adapter_config_or_name, handlers: handlers, formatters: formatters)
+      end
+    end
+
+    def translate(payload, &block)
+      tranlated_payload = translators[0].translate(payload)
+      translators[1].translate(yield(tranlated_payload))
+    end
+  end
+end
+
+
+

--- a/spec/payload_translator_spec.rb
+++ b/spec/payload_translator_spec.rb
@@ -5,12 +5,12 @@ require 'json'
 
 PayloadTranslator.configure do |config|
   config.adapters_configurations = {
-    internal_to_extenal: {
+    internal_to_external: {
       "payload" => {
         "id" => { "$field" => "_id" }
       }
     },
-    extenal_to_internal: {
+    external_to_internal: {
       "payload" => {
         "_id" => { "$field" => "id" }
       }
@@ -32,12 +32,12 @@ describe PayloadTranslator::Service do
 
   context "load adapters" do
     it '#translate to external' do
-      translator = PayloadTranslator::Service.new(:internal_to_extenal)
+      translator = PayloadTranslator::Service.new(:internal_to_external)
       expect(translator.translate({"_id" => "1234" })).to eq({"id"=>"1234"})
     end
 
     it '#translate to internal' do
-      translator = PayloadTranslator::Service.new(:extenal_to_internal)
+      translator = PayloadTranslator::Service.new(:external_to_internal)
       expect(translator.translate({"id" => "1234" })).to eq({"_id"=>"1234"})
     end
   end
@@ -94,6 +94,17 @@ describe PayloadTranslator::Service do
 
     it '#translate' do
       expect(subject.translate(input)).to eq("login_type" => "APP", "id" => 1)
+    end
+  end
+
+  context "with multiple translations" do
+    it '#translate multiple' do
+      translator = PayloadTranslator::ServiceMultiple.new([:internal_to_external, :external_to_internal])
+      translated_output = translator.translate({"_id" => "1"}) do |translated_input|
+        expect(translated_input).to eq({"id"=>"1"})
+        translated_input
+      end
+      expect(translated_output).to eq({"_id"=>"1"})
     end
   end
 


### PR DESCRIPTION
Allow translate input and output using block

```ruby
translator = PayloadTranslator::ServiceMultiple.new([:internal_to_external, :external_to_internal])

translated_response = translator.translate({"user_id" => 4 }) do |translated_payload|
  response = Net::HTTP.post_form(
    URI("https://jsonplaceholder.typicode.com/todos"),
    translated_payload
  ).body

  JSON.parse(response)
end
```
